### PR TITLE
Hotfix/1.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ When provided with a `\Twig\Loader\FilesystemLoader` parameter, the extension wi
 
 ### Functions
 
-#### `{{ class(<classes>) }}`
+#### `{{ html_classes(<classes>) }}`
 
 A function to manage classes more easily.
 
@@ -46,16 +46,16 @@ A function to manage classes more easily.
 **Examples**
 ```twig
 {# The following examples will render the same HTML #}
-<div class="{{ class('foo bar') }}"></div>
-<div class="{{ class(['foo', 'bar']) }}"></div>
-<div class="{{ class({ foo: true, bar: true, baz: false }) }}"></div>
-<div class="{{ class(['foo', { bar: true, baz: false }]) }}"></div>
+<div class="{{ html_classes('foo bar') }}"></div>
+<div class="{{ html_classes(['foo', 'bar']) }}"></div>
+<div class="{{ html_classes({ foo: true, bar: true, baz: false }) }}"></div>
+<div class="{{ html_classes(['foo', { bar: true, baz: false }]) }}"></div>
 
 {# HTML #}
 <div class="foo bar"></div>
 ```
 
-#### `{{ attributes(<attrs>) }}`
+#### `{{ html_attributes(<attrs>) }}`
 
 A function to render HTML attributes more easily with the following features:
 
@@ -69,7 +69,7 @@ A function to render HTML attributes more easily with the following features:
 
 **Examples**
 ```twig
-<div {{ attributes({ id: 'one', data_options: { label: 'close' }, required: true }) }}></div>
+<div {{ html_attributes({ id: 'one', data_options: { label: 'close' }, required: true }) }}></div>
 
 {# HTML #}
 <div id="one" data-options="{\"label\":\"close\"}" required></div>

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "studiometa/twig-toolkit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A set of useful extension and components for Twig.",
   "license": "MIT",
   "require": {

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -57,8 +57,13 @@ class Extension extends AbstractExtension
     public function getFunctions()
     {
         return [
+            /** @deprecated 1.0.1 Use the `html_classes` function instead. */
             new TwigFunction('class', [Html::class, 'renderClass']),
+            /** @deprecated 1.0.1 Use the `html_attributrs` function instead. */
             new TwigFunction('attributes', [Html::class, 'renderAttributes'], ['needs_environment' => true, 'is_safe' => ['html']]),
+
+            new TwigFunction('html_classes', [Html::class, 'renderClass']),
+            new TwigFunction('html_attributes', [Html::class, 'renderAttributes'], ['needs_environment' => true, 'is_safe' => ['html']]),
         ];
     }
 }

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -102,9 +102,11 @@ class Html
             // Convert keys to kebab-case
             $key = (new Convert($key))->toKebab();
 
-            // Push boolean attributes without value if true
-            if (is_bool($value) && $value) {
-                $renderedAttributes[] = $key;
+            // Push boolean attributes without value if true and skip to the next attribute
+            if (is_bool($value)) {
+                if ($value) {
+                    $renderedAttributes[] = $key;
+                }
                 continue;
             }
 

--- a/tests/Helpers/HtmlTest.php
+++ b/tests/Helpers/HtmlTest.php
@@ -8,51 +8,59 @@ beforeEach(function () {
     $this->twig = $twig;
 });
 
-test('The `{{ class() }}` Twig function should accept a string parameter.', function () {
+test('The `{{ html_classes() }}` Twig function should accept a string parameter.', function () {
     $tpl = <<<EOD
-    {{ class('block m-4') }}
+    {{ html_classes('block m-4') }}
     EOD;
     $this->loader->setTemplate('index', $tpl);
     expect($this->twig->render('index'))->toBe('block m-4');
 });
 
-test('The `{{ class() }}` Twig function should accept an array of string parameter.', function () {
+test('The `{{ html_classes() }}` Twig function should accept an array of string parameter.', function () {
     $tpl = <<<EOD
-    {{ class(['block', 'm-4']) }}
+    {{ html_classes(['block', 'm-4']) }}
     EOD;
     $this->loader->setTemplate('index', $tpl);
     expect($this->twig->render('index'))->toBe('block m-4');
 });
 
-test('The `{{ class() }}` Twig function should accept an object parameter', function () {
+test('The `{{ html_classes() }}` Twig function should accept an object parameter', function () {
     $tpl = <<<EOD
-    {{ class({ block: true, hidden: null, relative: false }) }}
+    {{ html_classes({ block: true, hidden: null, relative: false }) }}
     EOD;
     $this->loader->setTemplate('index', $tpl);
     expect($this->twig->render('index'))->toBe('block');
 });
 
-test('The `{{ class() }}` Twig function should work with dynamic test values.', function () {
+test('The `{{ html_classes() }}` Twig function should work with dynamic test values.', function () {
     $tpl = <<<EOD
     {% set is_block = true %}
-    {{ class({ block: is_block, relative: not is_block }) }}
+    {{ html_classes({ block: is_block, relative: not is_block }) }}
     EOD;
     $this->loader->setTemplate('index', $tpl);
     expect($this->twig->render('index'))->toBe('block');
 });
 
-test('The `{{ class() }}` Twig function should work with an array of string and object parameter.', function () {
+test('The `{{ html_classes() }}` Twig function should work with an array of string and object parameter.', function () {
     $tpl = <<<EOD
-    {{ class(['block', { foo: true, bar: false, }, 'm-4']) }}
+    {{ html_classes(['block', { foo: true, bar: false, }, 'm-4']) }}
     EOD;
     $this->loader->setTemplate('index', $tpl);
     expect($this->twig->render('index'))->toBe('block foo m-4');
 });
 
-test('The `{{ attributes() }}` Twig function should render attributes', function() {
+test('The `{{ html_attributes() }}` Twig function should render attributes', function() {
     $tpl = <<<EOD
-    {{ attributes({ id: 'foo', class: ['block', { foo: true, bar: false }], required: true, aria_hidden: 'true' }) }}
+    {{ html_attributes({ id: 'foo', class: ['block', { foo: true, bar: false }], required: true, aria_hidden: 'true' }) }}
     EOD;
     $this->loader->setTemplate('index', $tpl);
     expect($this->twig->render('index'))->toBe(' id="foo" class="block&#x20;foo" required aria-hidden="true"');
+});
+
+test('The `{{ html_attributes() }}` Twig function should not render falsy attributes', function() {
+    $tpl = <<<EOD
+    {{ html_attributes({ checked: true, autofocus: true, selected: false }) }}
+    EOD;
+    $this->loader->setTemplate('index', $tpl);
+    expect($this->twig->render('index'))->toBe(' checked autofocus');
 });


### PR DESCRIPTION
## Changed
- Rename the `class()` and `attributes()` Twig functions to `html_classes()` and `html_attributes()` (815cd6c)

## Fixed
- Fix a bug where falsy attributes were still added to the rendered attributes (e445a35)