### PR TITLE
Add a `html_styles()` Twig function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ A function to manage classes more easily.
 <div class="foo bar"></div>
 ```
 
+#### `{{ html_styles(<styles>) }}`
+
+A function to manage style attributes more easily.
+
+**Params**
+- `styles` (`Object`)
+
+**Examples**
+```twig
+<div style="{{ html_styles({ display: 'none', margin_top: '10px' }) }}"></div>
+<div style="display: none; margin-top: 10px"></div>
+
+<div style="{{ html_styles({ display: false, opacity: 0 }) }}"></div>
+<div style="opacity: 0;"></div>
+```
+
 #### `{{ html_attributes(<attrs>) }}`
 
 A function to render HTML attributes more easily with the following features:

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -63,6 +63,7 @@ class Extension extends AbstractExtension
             new TwigFunction('attributes', [Html::class, 'renderAttributes'], ['needs_environment' => true, 'is_safe' => ['html']]),
 
             new TwigFunction('html_classes', [Html::class, 'renderClass']),
+            new TwigFunction('html_styles', [Html::class, 'renderStyleAttribute']),
             new TwigFunction('html_attributes', [Html::class, 'renderAttributes'], ['needs_environment' => true, 'is_safe' => ['html']]),
         ];
     }

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -84,6 +84,37 @@ class Html
     }
 
     /**
+     * Render an array of CSS styles into a valid CSS string.
+     *
+     * @example
+     * ```php
+     * Html::renderStyleAttribute(['display' => 'none', 'pointer-events' => 'none']);
+     * // 'display: none; pointer-events: none;'
+     * ```
+     *
+     * @param  array  $styles The styles to render.
+     * @return string         The rendered styles.
+     */
+    public static function renderStyleAttribute(array $styles):string
+    {
+        $renderedStyle = [];
+
+        foreach ($styles as $property => $value) {
+            // Skip boolean values that are not true and empty strings
+            if (is_bool($value) && !$value || $value === '') {
+                continue;
+            }
+
+            // Convert property to kebab-case as it is the only
+            // valid case format for CSS properties.
+            $property = (new Convert($property))->toKebab();
+            $renderedStyle[] = sprintf('%s: %s;', $property, $value);
+        }
+
+        return implode(' ', $renderedStyle);
+    }
+
+    /**
      * Render an array of attributes.
      *
      * @example
@@ -113,6 +144,11 @@ class Html
             // Format class attributes
             if ($key === 'class') {
                 $value = static::renderClass($value);
+            }
+
+            // Format style attributes from array to string
+            if ($key === 'style' && is_array($value)) {
+                $value = static::renderStyleAttribute($value);
             }
 
             if (is_array($value)) {

--- a/tests/Helpers/HtmlTest.php
+++ b/tests/Helpers/HtmlTest.php
@@ -49,7 +49,15 @@ test('The `{{ html_classes() }}` Twig function should work with an array of stri
     expect($this->twig->render('index'))->toBe('block foo m-4');
 });
 
-test('The `{{ html_attributes() }}` Twig function should render attributes', function() {
+test('The `{{ html_styles() }}` Twig function should render inline CSS.', function () {
+    $tpl = <<<EOD
+    {{ html_styles({ display: 'none', marginRight: '', overflow: 0 != 0, margin_top: '10px' }) }}
+    EOD;
+    $this->loader->setTemplate('index', $tpl);
+    expect($this->twig->render('index'))->toBe('display: none; margin-top: 10px;');
+});
+
+test('The `{{ html_attributes() }}` Twig function should render attributes', function () {
     $tpl = <<<EOD
     {{ html_attributes({ id: 'foo', class: ['block', { foo: true, bar: false }], required: true, aria_hidden: 'true' }) }}
     EOD;
@@ -57,7 +65,7 @@ test('The `{{ html_attributes() }}` Twig function should render attributes', fun
     expect($this->twig->render('index'))->toBe(' id="foo" class="block&#x20;foo" required aria-hidden="true"');
 });
 
-test('The `{{ html_attributes() }}` Twig function should not render falsy attributes', function() {
+test('The `{{ html_attributes() }}` Twig function should not render falsy attributes', function () {
     $tpl = <<<EOD
     {{ html_attributes({ checked: true, autofocus: true, selected: false }) }}
     EOD;


### PR DESCRIPTION
To facilitate the customization of the `style` attribute, a new `{{ html_styles() }}` function is added to the Twig extension. It can be used as follows:

```twig
{# Twig #}
<ul>
  {% for item in items %}
    <li style="{{ html_styles({ display: loop.first ? 'none' : '' }) }}">...</li>
  {% endfor %}
</ul>

<!-- HTML -->
<ul>
  <li style="display: none;">...</li>
  <li>...</li>
</ul>
```

It will be used within the `{% html_element %}` tag when the `style` property is an object:  

```twig
{# Twig #}
{% html_element 'div' with { style: { display: 'none' } } %}
  ...
{% end_html_element %}

<!-- HTML -->
<div style="display: none;">
  ...
</div>
```