### PR TITLE
Add a check on html::renderClass to avoid warnings 

### DIFF
--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -58,6 +58,10 @@ class Html
      */
     public static function renderClass($class):string
     {
+        if (empty($class)) {
+            return '';
+        }
+
         if (is_string($class)) {
             return $class;
         }

--- a/tests/Helpers/HtmlTest.php
+++ b/tests/Helpers/HtmlTest.php
@@ -26,6 +26,14 @@ test('The `{{ html_classes() }}` Twig function should accept an array of string 
     assertMatchesSnapshot(test()->twig->render('index'));
 });
 
+test('The `{{ html_classes() }}` Twig function should accept an empty array.', function () {
+    $tpl = <<<EOD
+    {{ html_classes([]) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    assertMatchesSnapshot(test()->twig->render('index'));
+});
+
 test('The `{{ html_classes() }}` Twig function should accept an object parameter', function () {
     $tpl = <<<EOD
     {{ html_classes({ block: true, hidden: null, relative: false }) }}


### PR DESCRIPTION
When html_classes is use with empty array