### PR TITLE
[Release] 1.2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,16 +28,32 @@ jobs:
   phpstan:
     name: PHPStan
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.4', '8.0']
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache Composer dependencies
+      - name: Setup PHP, with composer and xdebug
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php-versions }}
+          coverage: xdebug
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+
+      - name: Cache composer dependencies
         uses: actions/cache@v2
         with:
-          path: /tmp/composer-cache
-          key: ${{ runner.os }}-${{ hashFiles('**/composer.lock') }}
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
 
-      - uses: php-actions/composer@v5
+      - name: Install Composer dependencies
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
 
       - name: PHPStan
         run: composer run phpstan

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ A function to render HTML attributes more easily with the following features:
 
 Merge HTML attributes smartly, useful to define default and required attributes at the component level and allow users to add custom ones.
 
+This filter can also be used as a function.
+
 **Params**
 - `attr` (`Object`): The user provided attributes
 - `default` (`Object`): The default attributes
@@ -120,16 +122,15 @@ You can define default and required attributes in a component's template:
  */
 #}
 
-{% set attributes = attr|default({}) %}
 {% set default_attributes = { class: 'bar' } %}
 {% set required_attributes = { data_component: 'Component' } %}
 
 {# Merge all attributes #}
-{% set final_attributes = attributes|merge_html_attributes(default_attributes, required_attributes)}
+{% set attributes = attr|merge_html_attributes(default_attributes, required_attributes)}
 
-<div {{ html_attributes(final_attributes)) }}></div>
+<div {{ html_attributes(attributes) }}></div>
 {# or #}
-{% html_element 'div' with final_attributes %}
+{% html_element 'div' with attributes %}
 ```
 
 And then include your component with custom attributes:

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "studiometa/twig-toolkit",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "A set of useful extension and components for Twig.",
   "license": "MIT",
   "require": {

--- a/composer.json
+++ b/composer.json
@@ -23,5 +23,10 @@
     "psr-4": {
       "Studiometa\\TwigToolkit\\": "src/"
     }
+  },
+  "config": {
+    "allow-plugins": {
+      "pestphp/pest-plugin": true
+    }
   }
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -74,6 +74,10 @@ class Extension extends AbstractExtension
                 [Html::class, 'renderAttributes'],
                 ['needs_environment' => true, 'is_safe' => ['html']]
             ),
+            new TwigFunction(
+                'merge_html_attributes',
+                [Html::class, 'mergeAttributes']
+            ),
         ];
     }
 

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -131,10 +131,22 @@ class Html
      * @return array
      */
     public static function mergeAttributes(
-        array $attributes,
-        array $default = [],
-        array $required = []
+        $attributes,
+        $default = [],
+        $required = []
     ):array {
+        if (empty($attributes)) {
+            $attributes = [];
+        }
+
+        if (empty($default)) {
+            $default = [];
+        }
+
+        if (empty($required)) {
+            $required = [];
+        }
+
         // Merge `class` attributes before the others
         $required['class'] = array_filter([
             $attributes['class'] ?? $default['class'] ?? '',

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -58,6 +58,10 @@ class Html
      */
     public static function renderClass($class):string
     {
+        if (empty($class)) {
+            return '';
+        }
+
         if (is_string($class)) {
             return $class;
         }

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -31,3 +31,31 @@ test('The extension should add the `merge_html_attributes` filter.', function ()
     test()->loader->setTemplate('index', $tpl);
     expect(test()->twig->render('index'))->toEqual(' id="baz"');
 });
+
+test('The `merge_html_attributes` filter can be used as a function.', function () {
+    $tpl = <<<EOD
+    {{ html_attributes(merge_html_attributes({ id: 'foo' }, { id: 'bar' }, { id: 'baz' })) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    expect(test()->twig->render('index'))->toEqual(' id="baz"');
+});
+
+test('The `merge_html_attributes` filter can be used with one or multiple undefined parameters.', function () {
+    $tpl = <<<EOD
+    {{ html_attributes(attr|merge_html_attributes({ id: 'bar' }, { id: 'baz' })) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    expect(test()->twig->render('index'))->toEqual(' id="baz"');
+
+    $tpl = <<<EOD
+    {{ html_attributes(merge_html_attributes(attr, { id: 'bar' }, { id: 'baz' })) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    expect(test()->twig->render('index'))->toEqual(' id="baz"');
+
+    $tpl = <<<EOD
+    {{ html_attributes(merge_html_attributes(attr, { id: 'bar' }, required_attr)) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    expect(test()->twig->render('index'))->toEqual(' id="bar"');
+});

--- a/tests/Helpers/HtmlTest.php
+++ b/tests/Helpers/HtmlTest.php
@@ -26,6 +26,14 @@ test('The `{{ html_classes() }}` Twig function should accept an array of string 
     assertMatchesSnapshot(test()->twig->render('index'));
 });
 
+test('The `{{ html_classes() }}` Twig function should accept an empty array.', function () {
+    $tpl = <<<EOD
+    {{ html_classes([]) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    assertMatchesSnapshot(test()->twig->render('index'));
+});
+
 test('The `{{ html_classes() }}` Twig function should accept an object parameter', function () {
     $tpl = <<<EOD
     {{ html_classes({ block: true, hidden: null, relative: false }) }}


### PR DESCRIPTION
## Changelog

### Added
- Add support for null parameters for the `merge_html_attributes` filter (4230c37, #10)
- Add a `merge_html_attributes` function based on the filter of the same name (fdddef2, #10)

### Fixed
- Fix warnings when using `html_classes` with an empty array (#9)