### PR TITLE
Hotfix/1.2.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
     steps:
       - uses: actions/checkout@v2
 
@@ -64,7 +64,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0']
+        php-versions: ['7.4', '8.0', '8.1']
     steps:
       - uses: actions/checkout@v2
 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "studiometa/twig-toolkit",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A set of useful extension and components for Twig.",
   "license": "MIT",
   "require": {

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -203,18 +203,20 @@ class Html
                 $value = json_encode($value);
             }
 
-            // Escape value and replace some escaped characters to improve
-            // readability for the generated HTML.
-            $value = str_replace(
-                ['&#x20;', '&#x3A;', '&#x3B;'],
-                [' ', ':', ';'],
-                twig_escape_filter($env, $value, 'html_attr', $env->getCharset())
-            );
+            $value = twig_escape_filter($env, $value, 'html_attr', $env->getCharset());
 
             // Do not add empty attributes
             if (empty($value)) {
                 continue;
             }
+
+            // Escape value and replace some escaped characters to improve
+            // readability for the generated HTML.
+            $value = str_replace(
+                ['&#x20;', '&#x3A;', '&#x3B;'],
+                [' ', ':', ';'],
+                $value
+            );
 
             $renderedAttributes[] = sprintf('%s="%s"', $key, $value);
         }


### PR DESCRIPTION
- Edit `renderAttributes` to be compliant with php8.1. Fix the warning: `Deprecated: str_replace(): Passing null to parameter #3 ($subject) of type array|string is deprecated`
- Add php8.1 to tests

## Changelog
### Fixed
- Fix a PHP warning with PHP 8.1 (#14, 8cce4429) 

### Changed
- Add PHP 8.1 to the tests