### PR TITLE
[Feature] Add a `twig_toolkit_url` function

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,11 @@ When provided with a `\Twig\Loader\FilesystemLoader` parameter, the extension wi
 A function to manage classes more easily.
 
 **Params**
+
 - `classes` (`String | Array | Object`)
 
 **Examples**
+
 ```twig
 {# The following examples will render the same HTML #}
 <div class="{{ html_classes('foo bar') }}"></div>
@@ -63,9 +65,11 @@ A function to manage classes more easily.
 A function to manage style attributes more easily.
 
 **Params**
+
 - `styles` (`Object`)
 
 **Examples**
+
 ```twig
 <div style="{{ html_styles({ display: 'none', margin_top: '10px' }) }}"></div>
 <div style="display: none; margin-top: 10px"></div>
@@ -84,9 +88,11 @@ A function to render HTML attributes more easily with the following features:
 - Values will be escaped to prevent XSS attacks
 
 **Params**
+
 - `attrs` (`Object`): The attributes to render
 
 **Examples**
+
 ```twig
 <div {{ html_attributes({ id: 'one', data_options: { label: 'close' }, required: true }) }}></div>
 
@@ -94,15 +100,14 @@ A function to render HTML attributes more easily with the following features:
 <div id="one" data-options="{\"label\":\"close\"}" required></div>
 ```
 
-### Filters
-
-### `{{ attr|merge_html_attributes(default, required) }}`
+#### `{{ merge_html_attributes(attr, default_attr, required_attr) }}`
 
 Merge HTML attributes smartly, useful to define default and required attributes at the component level and allow users to add custom ones.
 
 This filter can also be used as a function.
 
 **Params**
+
 - `attr` (`Object`): The user provided attributes
 - `default` (`Object`): The default attributes
 - `required` (`Object`): The required attributes
@@ -126,7 +131,7 @@ You can define default and required attributes in a component's template:
 {% set required_attributes = { data_component: 'Component' } %}
 
 {# Merge all attributes #}
-{% set attributes = attr|merge_html_attributes(default_attributes, required_attributes)}
+{% set attributes = merge_html_attributes(attr, default_attributes, required_attributes)}
 
 <div {{ html_attributes(attributes) }}></div>
 {# or #}
@@ -148,7 +153,25 @@ You can take advantage of [named arguments](http://twig.symfony.com/doc/3.x/temp
 
 ```twig
 {% set required_attributes = { id: 'block' } %}
-{{ attr|merge_html_attributes(required=required_attribute)}}
+{% set merged_attributes = merge_html_attributes(attr, required=required_attribute) %}
+```
+
+#### `{{ twig_toolkit_url(string) }}`
+
+Wrapper for the `Spatie\Url\Url` class to easily manipulate URLs. See the [`spatie/url` documentation](https://github.com/spatie/url) for details on its API.
+
+**Params**
+
+- `url` (`string`): The URL to parse for manipulation
+
+**Examples**
+
+```twig
+{# Change host #}
+{% set url = twig_toolkit_url(url).withHost('cdn.fqdn.com') %}
+
+{# Change/add query parameters #}
+{% set url = twig_toolkit_url(url).withQueryParameter('key', 'value') %}
 ```
 
 ### Tags
@@ -158,10 +181,12 @@ You can take advantage of [named arguments](http://twig.symfony.com/doc/3.x/temp
 Render an HTML element with the given attributes. Useful to avoid setting dynamic HTML element tags with the `<{{ tag }}>...</{{ tag }}>` pattern.
 
 **Params**
+
 - `tag` (`String`): The name of the tag
 - `attrs` (`Object`): An object describing the element's attribues
 
 **Examples**
+
 ```twig
 {# Twig #}
 {% html_element 'h1' with { class: 'block' } %}

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,8 @@
   "require": {
     "php": "^7.3|^8.0",
     "twig/twig": "^2.10|^3",
-    "jawira/case-converter": "^3.4"
+    "jawira/case-converter": "^3.4",
+    "spatie/url": "^1.3"
   },
   "require-dev": {
     "phpstan/phpstan": "^0.12.88",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fbe2bede7b8c696f5c2c642aed59bfde",
+    "content-hash": "5091eea0268701d6e2b47288e274256b",
     "packages": [
         {
             "name": "jawira/case-converter",
@@ -72,6 +72,161 @@
                 "source": "https://github.com/jawira/case-converter/tree/v3.4.6"
             },
             "time": "2021-11-21T19:52:51+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "reference": "f6561bf28d520154e4b0ec72be95418abe6d9363",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/master"
+            },
+            "time": "2016-08-06T14:39:51+00:00"
+        },
+        {
+            "name": "spatie/macroable",
+            "version": "1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/macroable.git",
+                "reference": "7a99549fc001c925714b329220dea680c04bfa48"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/macroable/zipball/7a99549fc001c925714b329220dea680c04bfa48",
+                "reference": "7a99549fc001c925714b329220dea680c04bfa48",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0|^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Macroable\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A trait to dynamically add methods to a class",
+            "homepage": "https://github.com/spatie/macroable",
+            "keywords": [
+                "macroable",
+                "spatie"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/macroable/issues",
+                "source": "https://github.com/spatie/macroable/tree/1.0.1"
+            },
+            "time": "2020-11-03T10:15:05+00:00"
+        },
+        {
+            "name": "spatie/url",
+            "version": "1.3.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/url.git",
+                "reference": "3633de58e0709ea98cecceff61ee51caf1fde7e3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/url/zipball/3633de58e0709ea98cecceff61ee51caf1fde7e3",
+                "reference": "3633de58e0709ea98cecceff61ee51caf1fde7e3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2|^8.0",
+                "psr/http-message": "^1.0",
+                "spatie/macroable": "^1.0.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.0|^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\Url\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian De Deyne",
+                    "email": "sebastian@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parse, build and manipulate URL's",
+            "homepage": "https://github.com/spatie/url",
+            "keywords": [
+                "spatie",
+                "url"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/url/issues",
+                "source": "https://github.com/spatie/url/tree/1.3.5"
+            },
+            "time": "2020-11-03T10:36:20+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -4105,5 +4260,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -17,6 +17,7 @@ use Twig\Loader\FilesystemLoader;
 use Twig\TokenParser\TokenParserInterface;
 use Twig\TwigFunction;
 use Twig\TwigFilter;
+use Spatie\Url\Url;
 
 /**
  * Twig extension class.
@@ -77,6 +78,10 @@ class Extension extends AbstractExtension
             new TwigFunction(
                 'merge_html_attributes',
                 [Html::class, 'mergeAttributes']
+            ),
+            new TwigFunction(
+                'twig_toolkit_url',
+                [Url::class, 'fromString'],
             ),
         ];
     }

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -59,3 +59,12 @@ test('The `merge_html_attributes` filter can be used with one or multiple undefi
     test()->loader->setTemplate('index', $tpl);
     expect(test()->twig->render('index'))->toEqual(' id="bar"');
 });
+
+test('The extension should add a `twig_toolkit_url` function', function() {
+    $tpl = <<<EOD
+    {{ twig_toolkit_url('/foo/bar').withQueryParameter('key', 'value') }}
+    EOD;
+
+    test()->loader->setTemplate('index', $tpl);
+    assertMatchesSnapshot(expect(test()->twig->render('index')));
+});

--- a/tests/__snapshots__/ExtensionTest__The_extension_should_add_a_twig_toolkit_url_function__1.yml
+++ b/tests/__snapshots__/ExtensionTest__The_extension_should_add_a_twig_toolkit_url_function__1.yml
@@ -1,0 +1,1 @@
+value: '/foo/bar?key=value'


### PR DESCRIPTION
This PR adds a `twig_toolkit_url` function which provide access to a `Spatie\Url\Url` instance from the [`spatie/url` package](https://github.com/spatie/url).

## Changelog

### Added
- Add a `twig_toolkit_url` function to wrap a string in a `Spatie\Url\Url` instance 