### PR TITLE
[Hotfix] 1.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v1.3.5 (2023-07-13)
+
+### Fixed
+
+- Fix handling of CSS custom properties by the `html_styles` function ([2ce4f36](https://github.com/studiometa/twig-toolkit/commit/2ce4f36))
+
 ## v1.3.4 (2022-12-06)
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require-dev": {
     "phpstan/phpstan": "^0.12.88",
     "squizlabs/php_codesniffer": "^3.6",
-    "pestphp/pest": "^1.3",
+    "pestphp/pest": "^1.22",
     "spatie/pest-plugin-snapshots": "^1.0"
   },
   "scripts": {

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "studiometa/twig-toolkit",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A set of useful extension and components for Twig.",
   "license": "MIT",
   "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95b962c152495b8e8efc402013dfe59e",
+    "content-hash": "502c9c9ad4c2b2a9dffb323e33d01d58",
     "packages": [
         {
             "name": "jawira/case-converter",
@@ -869,16 +869,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v1.21.2",
+            "version": "v1.22.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "63f009fadf9b37f611fda43928d03336475d5d9f"
+                "reference": "af6240b4eed8b049ac43c91184141ee337305df7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/63f009fadf9b37f611fda43928d03336475d5d9f",
-                "reference": "63f009fadf9b37f611fda43928d03336475d5d9f",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/af6240b4eed8b049ac43c91184141ee337305df7",
+                "reference": "af6240b4eed8b049ac43c91184141ee337305df7",
                 "shasum": ""
             },
             "require": {
@@ -900,7 +900,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.x-dev"
+                    "dev-1.x": "1.x-dev"
                 },
                 "pest": {
                     "plugins": [
@@ -946,7 +946,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v1.21.2"
+                "source": "https://github.com/pestphp/pest/tree/v1.22.1"
             },
             "funding": [
                 {
@@ -978,7 +978,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2022-03-05T19:34:40+00:00"
+            "time": "2022-08-29T10:42:13+00:00"
         },
         {
             "name": "pestphp/pest-plugin",

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -110,8 +110,11 @@ class Html
             }
 
             // Convert property to kebab-case as it is the only
-            // valid case format for CSS properties.
-            $property = (new Convert($property))->toKebab();
+            // valid case format for CSS properties, but only if
+            // it is not a CSS custom variable starting with `--`.
+            if (strpos($property, '--') !== 0) {
+                $property = (new Convert($property))->toKebab();
+            }
             $renderedStyle[] = sprintf('%s: %s;', $property, $value);
         }
 

--- a/tests/Helpers/HtmlTest.php
+++ b/tests/Helpers/HtmlTest.php
@@ -67,6 +67,14 @@ test('The `{{ html_styles() }}` Twig function should render inline CSS.', functi
     assertMatchesSnapshot(test()->twig->render('index'));
 });
 
+test('The `{{ html_styles() }}` Twig function should render inline CSS with CSS custom properties.', function () {
+    $tpl = <<<EOD
+    {{ html_styles({ '--var': 'none', margin_right: '10px' }) }}
+    EOD;
+    test()->loader->setTemplate('index', $tpl);
+    assertMatchesSnapshot(test()->twig->render('index'));
+});
+
 test('The `{{ html_attributes() }}` Twig function should render attributes', function () {
     $tpl = <<<EOD
     {{ html_attributes({

--- a/tests/__snapshots__/HtmlTest__The__html_styles()__Twig_function_should_render_inline_CSS_with_CSS_custom_properties.__1.txt
+++ b/tests/__snapshots__/HtmlTest__The__html_styles()__Twig_function_should_render_inline_CSS_with_CSS_custom_properties.__1.txt
@@ -1,0 +1,1 @@
+--var: none; margin-right: 10px;


### PR DESCRIPTION
### Fixed

- Fix handling of CSS custom properties by the `html_styles` function ([2ce4f36](https://github.com/studiometa/twig-toolkit/commit/2ce4f36))