### PR TITLE
[Hotfix] 1.3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v1.3.7 (2024-09-18)
+
+### Fixed
+
+- Fix attribute rendering by omitting `null` or `false` attributes instead of empty attributes ([#26](https://github.com/studiometa/twig-toolkit/pull/26))
+
 ## v1.3.6 (2024-04-18)
 
 ### Fixed

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -208,8 +208,8 @@ class Html
 
             $value = twig_escape_filter($env, $value, 'html_attr', $env->getCharset());
 
-            // Do not add empty attributes
-            if (empty($value)) {
+            // Do not add empty attributes, unless it is alt
+            if (empty($value) && $key !== 'alt') {
                 continue;
             }
 

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -208,8 +208,8 @@ class Html
 
             $value = twig_escape_filter($env, $value, 'html_attr', $env->getCharset());
 
-            // Do not add empty attributes, unless it is alt
-            if (empty($value) && $key !== 'alt') {
+            // Do not add null & false attributes
+            if (is_null($value) || $value === false) {
                 continue;
             }
 

--- a/tests/Helpers/HtmlTest.php
+++ b/tests/Helpers/HtmlTest.php
@@ -99,7 +99,7 @@ test('The `{{ html_attributes() }}` Twig function should not render falsy attrib
 
 test('The `{{ html_attributes() }}` Twig function should not render empty attributes', function () {
     $tpl = <<<EOD
-    {{ html_attributes({ empty_string: '', nullish: null, empty_array: [] }) }}
+    {{ html_attributes({ empty_string: '', truthy: true, falsy: false, nullish: null, empty_array: [] }) }}
     EOD;
     test()->loader->setTemplate('index', $tpl);
     assertMatchesSnapshot(test()->twig->render('index'));

--- a/tests/__snapshots__/HtmlTest__The__html_attributes()__Twig_function_should_not_render_empty_attributes__1.txt
+++ b/tests/__snapshots__/HtmlTest__The__html_attributes()__Twig_function_should_not_render_empty_attributes__1.txt
@@ -1,1 +1,1 @@
- empty-array="&#x5B;&#x5D;"
+ empty-string="" truthy empty-array="&#x5B;&#x5D;"


### PR DESCRIPTION
## v1.3.7 (2024-09-18)

### Fixed
- Fix `renderAttributes` to always render alt has it is a mandatory attribute for <img> tags ([#26](https://github.com/studiometa/twig-toolkit/pull/26))