### PR TITLE
[Bugfix] Fix attribute escaping strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Prefer the `html` escape mode to the `html_attr` ([#33](https://github.com/studiometa/twig-toolkit/pull/33), [c093446](https://github.com/studiometa/twig-toolkit/commit/c093446))
+
 ## v2.0.0 (2025-01-20)
 
 ### Changed

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -210,20 +210,12 @@ class Html
             }
 
             /** @var null|false|string */
-            $value = $env->getRuntime(EscaperRuntime::class)->escape($value, 'html_attr', $env->getCharset());
+            $value = $env->getRuntime(EscaperRuntime::class)->escape($value, 'html', $env->getCharset());
 
             // Do not add null & false attributes
             if (is_null($value) || $value === false) {
                 continue;
             }
-
-            // Escape value and replace some escaped characters to improve
-            // readability for the generated HTML.
-            $value = str_replace(
-                ['&#x20;', '&#x3A;', '&#x3B;', '&#x2F;'],
-                [' ', ':', ';', '/'],
-                $value
-            );
 
             $renderedAttributes[] = sprintf('%s="%s"', $key, $value);
         }

--- a/tests/__snapshots__/ElementTokenParserTest__The_____html__element_____Twig_tag_should_be_able_to_render_complex_attributes___1.txt
+++ b/tests/__snapshots__/ElementTokenParserTest__The_____html__element_____Twig_tag_should_be_able_to_render_complex_attributes___1.txt
@@ -1,3 +1,3 @@
-<div aria-hidden="true" data-options="&#x7B;&quot;log&quot;:true&#x7D;">
+<div aria-hidden="true" data-options="{&quot;log&quot;:true}">
     Hello world
 </div>

--- a/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_not_render_empty_attributes__1.txt
+++ b/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_not_render_empty_attributes__1.txt
@@ -1,1 +1,1 @@
- empty-string="" truthy empty-array="&#x5B;&#x5D;"
+ empty-string="" truthy empty-array="[]"

--- a/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_prevent_XSS_attacks__1.txt
+++ b/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_prevent_XSS_attacks__1.txt
@@ -1,1 +1,1 @@
- class="&quot; onclick&#x3D;&quot;alert&#x28;true&#x29;"
+ class="&quot; onclick=&quot;alert(true)"


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

No issue.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Twig documentation on escape strategies explains that the `html_attr` escape strategy should be used to escape a string for the HTML attribute context, without quotes around HTML attribute values. The `Html` class only uses attribute values inside quotes, so we can switch to the simpler `html` escape strategy. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
