### PR TITLE
[Release] 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+## v2.0.1 (2025-01-27)
+
 ### Changed
 
 - Prefer the `html` escape mode to the `html_attr` ([#33](https://github.com/studiometa/twig-toolkit/pull/33), [c093446](https://github.com/studiometa/twig-toolkit/commit/c093446))
+- Update composer.lock file ([15c83b4](https://github.com/studiometa/twig-toolkit/commit/15c83b4))
 
 ## v2.0.0 (2025-01-20)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Prefer the `html` escape mode to the `html_attr` ([#33](https://github.com/studiometa/twig-toolkit/pull/33), [c093446](https://github.com/studiometa/twig-toolkit/commit/c093446))
+
 ## v2.0.0 (2025-01-20)
 
 ### Changed

--- a/composer.lock
+++ b/composer.lock
@@ -74,16 +74,16 @@
         },
         {
             "name": "psr/http-message",
-            "version": "1.1",
+            "version": "2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/http-message.git",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba"
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
-                "reference": "cb6ce4845ce34a8ad9e68117c10ee90a29919eba",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
                 "shasum": ""
             },
             "require": {
@@ -92,7 +92,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.1.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -107,7 +107,7 @@
             "authors": [
                 {
                     "name": "PHP-FIG",
-                    "homepage": "http://www.php-fig.org/"
+                    "homepage": "https://www.php-fig.org/"
                 }
             ],
             "description": "Common interface for HTTP messages",
@@ -121,26 +121,26 @@
                 "response"
             ],
             "support": {
-                "source": "https://github.com/php-fig/http-message/tree/1.1"
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
-            "time": "2023-04-04T09:50:52+00:00"
+            "time": "2023-04-04T09:54:51+00:00"
         },
         {
             "name": "spatie/macroable",
-            "version": "1.0.1",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/macroable.git",
-                "reference": "7a99549fc001c925714b329220dea680c04bfa48"
+                "reference": "ec2c320f932e730607aff8052c44183cf3ecb072"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/macroable/zipball/7a99549fc001c925714b329220dea680c04bfa48",
-                "reference": "7a99549fc001c925714b329220dea680c04bfa48",
+                "url": "https://api.github.com/repos/spatie/macroable/zipball/ec2c320f932e730607aff8052c44183cf3ecb072",
+                "reference": "ec2c320f932e730607aff8052c44183cf3ecb072",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2|^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.0|^9.3"
@@ -171,9 +171,9 @@
             ],
             "support": {
                 "issues": "https://github.com/spatie/macroable/issues",
-                "source": "https://github.com/spatie/macroable/tree/1.0.1"
+                "source": "https://github.com/spatie/macroable/tree/2.0.0"
             },
-            "time": "2020-11-03T10:15:05+00:00"
+            "time": "2021-03-26T22:39:02+00:00"
         },
         {
             "name": "spatie/url",
@@ -824,16 +824,16 @@
         },
         {
             "name": "filp/whoops",
-            "version": "2.16.0",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filp/whoops.git",
-                "reference": "befcdc0e5dce67252aa6322d82424be928214fa2"
+                "reference": "075bc0c26631110584175de6523ab3f1652eb28e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filp/whoops/zipball/befcdc0e5dce67252aa6322d82424be928214fa2",
-                "reference": "befcdc0e5dce67252aa6322d82424be928214fa2",
+                "url": "https://api.github.com/repos/filp/whoops/zipball/075bc0c26631110584175de6523ab3f1652eb28e",
+                "reference": "075bc0c26631110584175de6523ab3f1652eb28e",
                 "shasum": ""
             },
             "require": {
@@ -883,7 +883,7 @@
             ],
             "support": {
                 "issues": "https://github.com/filp/whoops/issues",
-                "source": "https://github.com/filp/whoops/tree/2.16.0"
+                "source": "https://github.com/filp/whoops/tree/2.17.0"
             },
             "funding": [
                 {
@@ -891,7 +891,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-25T12:00:00+00:00"
+            "time": "2025-01-25T12:00:00+00:00"
         },
         {
             "name": "jean85/pretty-package-versions",
@@ -1843,16 +1843,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "cd6e973e04b4c2b94c86e8612b5a65f0da0e08e7"
+                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cd6e973e04b4c2b94c86e8612b5a65f0da0e08e7",
-                "reference": "cd6e973e04b4c2b94c86e8612b5a65f0da0e08e7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/7d08f569e582ade182a375c366cbd896eccadd3a",
+                "reference": "7d08f569e582ade182a375c366cbd896eccadd3a",
                 "shasum": ""
             },
             "require": {
@@ -1897,7 +1897,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-05T16:43:48+00:00"
+            "time": "2025-01-21T14:54:06+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -3481,16 +3481,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.11.2",
+            "version": "3.11.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079"
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/1368f4a58c3c52114b86b1abe8f4098869cb0079",
-                "reference": "1368f4a58c3c52114b86b1abe8f4098869cb0079",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
+                "reference": "ba05f990e79cbe69b9f35c8c1ac8dca7eecc3a10",
                 "shasum": ""
             },
             "require": {
@@ -3555,9 +3555,13 @@
                 {
                     "url": "https://opencollective.com/php_codesniffer",
                     "type": "open_collective"
+                },
+                {
+                    "url": "https://thanks.dev/phpcsstandards",
+                    "type": "thanks_dev"
                 }
             ],
-            "time": "2024-12-11T16:04:26+00:00"
+            "time": "2025-01-23T17:04:15+00:00"
         },
         {
             "name": "symfony/console",

--- a/src/Helpers/Html.php
+++ b/src/Helpers/Html.php
@@ -210,20 +210,12 @@ class Html
             }
 
             /** @var null|false|string */
-            $value = $env->getRuntime(EscaperRuntime::class)->escape($value, 'html_attr', $env->getCharset());
+            $value = $env->getRuntime(EscaperRuntime::class)->escape($value, 'html', $env->getCharset());
 
             // Do not add null & false attributes
             if (is_null($value) || $value === false) {
                 continue;
             }
-
-            // Escape value and replace some escaped characters to improve
-            // readability for the generated HTML.
-            $value = str_replace(
-                ['&#x20;', '&#x3A;', '&#x3B;', '&#x2F;'],
-                [' ', ':', ';', '/'],
-                $value
-            );
 
             $renderedAttributes[] = sprintf('%s="%s"', $key, $value);
         }

--- a/tests/__snapshots__/ElementTokenParserTest__The_____html__element_____Twig_tag_should_be_able_to_render_complex_attributes___1.txt
+++ b/tests/__snapshots__/ElementTokenParserTest__The_____html__element_____Twig_tag_should_be_able_to_render_complex_attributes___1.txt
@@ -1,3 +1,3 @@
-<div aria-hidden="true" data-options="&#x7B;&quot;log&quot;:true&#x7D;">
+<div aria-hidden="true" data-options="{&quot;log&quot;:true}">
     Hello world
 </div>

--- a/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_not_render_empty_attributes__1.txt
+++ b/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_not_render_empty_attributes__1.txt
@@ -1,1 +1,1 @@
- empty-string="" truthy empty-array="&#x5B;&#x5D;"
+ empty-string="" truthy empty-array="[]"

--- a/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_prevent_XSS_attacks__1.txt
+++ b/tests/__snapshots__/HtmlTest__The_____html__attributes_______Twig_function_should_prevent_XSS_attacks__1.txt
@@ -1,1 +1,1 @@
- class="&quot; onclick&#x3D;&quot;alert&#x28;true&#x29;"
+ class="&quot; onclick=&quot;alert(true)"


### PR DESCRIPTION
### Changed

- Prefer the `html` escape mode to the `html_attr` ([#33](https://github.com/studiometa/twig-toolkit/pull/33), [c093446](https://github.com/studiometa/twig-toolkit/commit/c093446))
- Update composer.lock file ([15c83b4](https://github.com/studiometa/twig-toolkit/commit/15c83b4))
