### PR TITLE
[Feature] Add a `twig_toolkit_without` filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Added
+
+- Add a `twig_toolkit_without` filter ([#36](https://github.com/studiometa/twig-toolkit/pull/36), [b2842a2](https://github.com/studiometa/twig-toolkit/commit/b2842a2))
+
 ### Fixed
 
 - Fix Twig 3.21 deprecations ([#35](https://github.com/studiometa/twig-toolkit/pull/35), [6687590](https://github.com/studiometa/twig-toolkit/commit/6687590))

--- a/README.md
+++ b/README.md
@@ -163,6 +163,27 @@ Wrapper for the `Spatie\Url\Url` class to easily manipulate URLs. See the [`spat
 {% set url = twig_toolkit_url(url).withQueryParameter('key', 'value') %}
 ```
 
+### Filters
+
+#### `{{ object|twig_toolkit_without('key', 'other_key') }}`
+
+Returns the given hash without the specified keys.
+
+**Params**
+
+- `value` (`array`): the hash to remove the key from
+- `...keys` (`string[]`): the keys to remove
+
+**Examples**
+
+```twig
+{# Twig #}
+{{ { foo: 1, bar: 2, baz: 3 }|twig_toolkit_without('bar')|keys|join(', ') }}
+
+{# HTML #}
+foo, baz
+```
+
 ### Tags
 
 #### `{% html_element '<tag>' with attrs %}`

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -4,6 +4,9 @@
   <exclude-pattern>/vendor/</exclude-pattern>
 
   <file>src</file>
+  <arg name="colors" />
+  <arg name="cache" />
+  <arg value="sp" />
 
   <!--
     Ending tags '?>' can be really painful to debug.

--- a/src/Extension.php
+++ b/src/Extension.php
@@ -12,6 +12,7 @@ use Studiometa\TwigToolkit\Helpers\Url;
 use Studiometa\TwigToolkit\TokenParser\ElementTokenParser;
 use Twig\Extension\AbstractExtension;
 use Twig\TokenParser\TokenParserInterface;
+use Twig\TwigFilter;
 use Twig\TwigFunction;
 
 /**
@@ -57,6 +58,21 @@ class Extension extends AbstractExtension
                 'twig_toolkit_url',
                 [Url::class, 'fromString'],
             ),
+        ];
+    }
+
+    public function getFilters()
+    {
+        return [
+            new TwigFilter('twig_toolkit_without', function (array $array, string ...$keys) {
+                $clone = $array;
+
+                foreach ($keys as $key) {
+                    unset($clone[$key]);
+                }
+
+                return $clone;
+            }),
         ];
     }
 }

--- a/tests/ExtensionTest.php
+++ b/tests/ExtensionTest.php
@@ -49,3 +49,13 @@ test('The `twig_toolkit_url` function should not encode URL parameters', functio
     test()->loader->setTemplate('index', $tpl);
     expect(test()->twig->render('index'))->toBe('/foo/bar?twic=v1/output=preview');
 });
+
+test('The `twig_toolkit_without` filter removes keys from the given object', function () {
+    $tpl = <<<EOD
+    {% set result = { foo: 'foo', bar: 'baz', buz: 'buz', fee: true }|twig_toolkit_without('bar', 'buz', 'biz') %}
+    {{ result|keys|join(', ') }}
+    EOD;
+
+    test()->loader->setTemplate('index', $tpl);
+    expect(test()->twig->render('index'))->toBe('foo, fee');
+});


### PR DESCRIPTION
<!---
☝️ PR title should be prefixed by [Feature], [Bugfix], [Release] or [Hotfix]
-->

### 🔗 Linked issue

https://github.com/studiometa/ui/pull/196

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds a new `twig_toolkit_without` filter to easily remove keys from a given object. 

```twig
{# Twig #}
{{ { foo: 1, bar: 2, baz: 3 }|twig_toolkit_without('bar')|keys|join(', ') }}

{# HTML #}
foo, baz
```

It is prefixed to avoid conflict with other implementation (i.e. in Drupal).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have added tests (if possible).
- [x] I have updated the documentation accordingly.
- [x] I have updated the changelog.
